### PR TITLE
Bump version to 1.8.0 : use locate_template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,16 @@
 # Change Log for Page Template Dashboard
 
-As of 1.7.0, all notable changes to this project will be documented
+As of 1.8.0, all notable changes to this project will be documented
 in this file. This project adheres to [Semantic Versioning](http://semver.org/).
+
+## 1.8.0
+
+* Verifies WordPress 4.9 compatibility.
+
+### Changed
+
+* Fix bug : Could not find a template name in a parent theme.
+* Fix bug : Stop using get_file_description function that was not always working (use another way).
 
 ## 1.7.0
 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,10 @@ For more information or to follow the project, check out the [project page](http
 2. Upload the `page-template-dashboard` directory to your `wp-content/plugins` directory
 3. Activate the plugin on the WordPress Plugins dashboard
 
+### Using Composer 
+
+1. `composer require wpackagist-plugin/page-template-dashboard`
+
 ## Notes
 
 Page Template Dashboard...

--- a/README.txt
+++ b/README.txt
@@ -1,10 +1,10 @@
 === Page Template Dashboard ===
-Contributors: tommcfarlin
+Contributors: tommcfarlin, Mista-Flo
 Donate link: https://tommcfarlin.com/projects/page-template-dashboard/
 Tags: page, templates
 Requires at least: 3.4
-Tested up to: 4.7.0
-Stable tag: 1.7.0
+Tested up to: 4.9.8
+Stable tag: 1.8.0
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -30,21 +30,31 @@ For more information or to follow the project, check out the [GitHub repository]
 = Using The WordPress Dashboard =
 
 1. Navigate to the 'Add New' Plugin Dashboard
-1. Select `page-template-dashboard.zip` from your computer
-1. Upload
-1. Activate the plugin on the WordPress Plugin Dashboard
+2. Select `page-template-dashboard.zip` from your computer
+3. Upload
+4. Activate the plugin on the WordPress Plugin Dashboard
 
 = Using FTP =
 
 1. Extract `page-template-dashboard.zip` to your computer
-1. Upload the `page-template-dashboard` directory to your `wp-content/plugins` directory
-1. Activate the plugin on the WordPress Plugins dashboard
+2. Upload the `page-template-dashboard` directory to your `wp-content/plugins` directory
+3. Activate the plugin on the WordPress Plugins dashboard
+
+= Using Composer =
+
+1. composer require wpackagist-plugin/page-template-dashboard
 
 == Screenshots ==
 
 1. The Pages Dashboard with the plugin activated.
 
 == Changelog ==
+
+= 1.8.0 =
+
+* Verifies WordPress 4.9 compatibility.
+* Fix bug : Could not find a template name in a parent theme.
+* Fix bug : Stop using get_file_description function that was not always working (use another way).
 
 = 1.7.0 =
 
@@ -61,6 +71,7 @@ For more information or to follow the project, check out the [GitHub repository]
 * Verifying WordPress 4.2.1 compatibility
 
 = 1.5.0 =
+
 * Verifying WordPress 4.1 compatibility
 
 = 1.4.0 =
@@ -82,15 +93,18 @@ For more information or to follow the project, check out the [GitHub repository]
 * Added LICENSE.txt
 
 = 1.1 =
+
 * Adding Finnish translation (thanks to <a href="http://twitter.com/SipuliSopuli/">Timi Wahalahti</a>)
 * Adding support for child themes (thanks to <a href="http://twitter.com/MaorH">Maor Chasen's</a> suggestion)
 * Using `get_page_template_slug` instead of reading Post Meta Data (thanks to <a href="http://twitter.com/MaorH/">Maor Chasen's</a> suggestion)
 * Updating the screenshot
 
 = 1.0.1 =
+
 * Minor update to the screenshot and the Development Information
 
 = 1.0 =
+
 * Initial release
 
 == Development Information ==

--- a/class-page-template-dashboard.php
+++ b/class-page-template-dashboard.php
@@ -83,17 +83,18 @@ class Page_Template_Dashboard {
 
 		// First, the get name of the template.
 		$template_name = get_page_template_slug( $post->ID );
-		$template      = untrailingslashit( get_stylesheet_directory() ) . '/' . $template_name;
 
-		/**
-		 * If the file name is empty or the template file doesn't exist (because, say,
-		 * meta data is left from a previous theme).
-		 * Otherwise, let's actually get the friendly name of the file rather than the name of the file itself
-		 * by using the WordPress `get_file_description` function
-		 */
-		$template_name = ( 0 === strlen( trim( $template_name ) ) || ! file_exists( $template ) ) ?
-			 __( 'Default', 'page-template-dashboard-locale' ) :
-			get_file_description( $template );
+		// Locate template from the child or parent theme.
+		$template = locate_template( $template_name, false, false );
+		if ( ! empty( $template ) ) {
+			// Get template name in the header comment of the file
+			$template_data = implode( '', file( $template ) );
+			if ( preg_match( '|Template Name:(.*)$|mi', $template_data, $name ) ) {
+				$template_name = _cleanup_header_comment( $name[1] );
+			}
+		} else {
+			$template_name = __( 'Default', 'page-template-dashboard-locale' );
+		}
 
 		// Finally, render the template name.
 		echo esc_html( $template_name );

--- a/page-template-dashboard.php
+++ b/page-template-dashboard.php
@@ -14,7 +14,7 @@
  * Plugin Name: Page Template Dashboard
  * Plugin URI:  https://tommcfarlin.com/page-template-dashboard/
  * Description: An easy way to see which templates your pages are using without having to view the page editor.
- * Version:     1.7.0
+ * Version:     1.8.0
  * Author:      Tom McFarlin
  * Author URI:  https://tommcfarlin.com/
  * Text Domain: page-template-dashboard-locale


### PR DESCRIPTION
Hi,

Scenario to reproduce : 
Have a child and a parent theme with the child theme activated.
Have the template file only in the parent theme folder and not on the child folder
Then, the plugin display "Default template" instead of the parent theme template.

Fixes : 
I fixed this issue by using native function of WordPress locate_template which search a template file in the child theme first, then in the parent theme.

I have also found a bug with the get_file_description which was not working with me, so I have just used the lines that I need to display the comment header name from the file.

PS : Not sure if it's the good version name : 1.8.0 or a 1.7.1