### PR TITLE
Add custom post type support

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ add_filter( 'page_template_dashboard_post_types', 'show_template_for_custom_post
 function show_template_for_custom_post_type ($post_types) {
     $post_types[] = 'my_post_type';
     return $post_types;
-});
+}
 ```
 
 ## Notes

--- a/README.md
+++ b/README.md
@@ -38,6 +38,23 @@ For more information or to follow the project, check out the [project page](http
 
 1. `composer require wpackagist-plugin/page-template-dashboard`
 
+## Hooks
+
+Page Template Dashboard offers hooks to customize the plugin. You can add your hooks into your theme `functions.php`.
+
+__page_template_dashboard_post_types__
+
+Add or adjust which custom post types show the template column in the admin.
+
+```
+add_filter( 'page_template_dashboard_post_types', 'show_template_for_custom_post_type');
+
+function show_template_for_custom_post_type ($post_types) {
+    $post_types[] = 'my_post_type';
+    return $post_types;
+});
+```
+
 ## Notes
 
 Page Template Dashboard...

--- a/class-page-template-dashboard.php
+++ b/class-page-template-dashboard.php
@@ -23,32 +23,48 @@ class Page_Template_Dashboard {
 	 */
 	public function init() {
 
-		add_action(
-			'init',
-			array( $this, 'plugin_textdomain' )
-		);
-
-	    add_filter(
-			'manage_edit-page_columns',
-			array( $this, 'add_template_column' )
-		);
-
-	    add_action(
-			'manage_page_posts_custom_column',
-			array( $this, 'add_template_data' )
-		);
+		$this->load_plugin_textdomain();
+		$this->register_admin_columns();
+	    
 	}
 
 	/**
 	 * Loads the plugin text domain for translation.
 	 */
-	public function plugin_textdomain() {
+	public function load_plugin_textdomain() {
 
 		load_plugin_textdomain(
 			'page-template-dashboard',
 			false,
 			dirname( plugin_basename( __FILE__ ) ) . '/lang'
 		);
+	}
+
+	public function register_admin_columns() {
+		$post_types = $this->get_post_types();
+		
+		foreach ($post_types as $post_type) {
+			add_filter(
+				"manage_{$post_type}_posts_columns",
+				array( $this, 'add_template_column' )
+			);
+			
+			
+			add_action(
+				"manage_{$post_type}_posts_custom_column",
+				array( $this, 'add_template_data' )
+			);
+		}
+	}
+
+	/**
+	 * Get a list of post types to register the column for
+	 *
+	 * @return array $post_types
+	 */
+	public function get_post_types() {
+		$default_post_types = array('page');
+		return apply_filters( 'page_template_dashboard_post_types', $default_post_types );
 	}
 
 	/**

--- a/class-page-template-dashboard.php
+++ b/class-page-template-dashboard.php
@@ -40,6 +40,11 @@ class Page_Template_Dashboard {
 		);
 	}
 
+	/**
+	 * Add the custom admin column to post types
+	 *
+	 * @return void
+	 */
 	public function register_admin_columns() {
 		$post_types = $this->get_post_types();
 		

--- a/page-template-dashboard.php
+++ b/page-template-dashboard.php
@@ -27,7 +27,7 @@ defined( 'WPINC' ) || die;
 
 include_once 'class-page-template-dashboard.php' ;
 
-add_action( 'plugins_loaded', 'ptd_start' );
+add_action( 'init', 'ptd_start' );
 /**
  * Starts the plugin.
  */


### PR DESCRIPTION
Adds support for showing admin column on custom post types via a documented filter `page_template_dashboard_post_types`. Resolves #10 