### PR TITLE
Show template filename via hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,18 @@ For more information or to follow the project, check out the [project page](http
 
 1. `composer require wpackagist-plugin/page-template-dashboard`
 
+## Hooks
+
+Page Template Dashboard offers hooks to customize the plugin. You can add your hooks into your theme `functions.php`.
+
+__page_template_dashboard_show_filename__
+
+Show the filename in addition to the template name. Default is `false`.
+
+```
+add_filter( 'page_template_dashboard_show_filename', '__return_true' );
+```
+
 ## Notes
 
 Page Template Dashboard...

--- a/class-page-template-dashboard.php
+++ b/class-page-template-dashboard.php
@@ -82,15 +82,22 @@ class Page_Template_Dashboard {
 		global $post;
 
 		// First, the get name of the template.
-		$template_name = get_page_template_slug( $post->ID );
+		$template_slug = get_page_template_slug( $post->ID );
+		$template_name = $template_slug;
 
 		// Locate template from the child or parent theme.
-		$template = locate_template( $template_name, false, false );
+		$template = locate_template( $template_slug, false, false );
 		if ( ! empty( $template ) ) {
 			// Get template name in the header comment of the file
 			$template_data = implode( '', file( $template ) );
 			if ( preg_match( '|Template Name:(.*)$|mi', $template_data, $name ) ) {
 				$template_name = _cleanup_header_comment( $name[1] );
+			}
+			if ( 
+				$show_filename = apply_filters( 'page_template_dashboard_show_filename', false ) 
+				&& $template_name !== $template_slug
+			) {
+				$template_name .= " ({$template_slug})";
 			}
 		} else {
 			$template_name = __( 'Default', 'page-template-dashboard-locale' );

--- a/page-template-dashboard.php
+++ b/page-template-dashboard.php
@@ -27,7 +27,7 @@ defined( 'WPINC' ) || die;
 
 include_once 'class-page-template-dashboard.php' ;
 
-add_action( 'plugins_loaded', 'ptd_start' );
+add_action( 'init', 'ptd_start' );
 /**
  * Starts the plugin.
  */


### PR DESCRIPTION
Often times, it is helpful for developers to be able to see the actual filename in addition to the "given name" of the page/post template. This adds a filter that allows a user to see the filename in parentheses after the actual template name in the admin column.

![show_filename](https://user-images.githubusercontent.com/7256402/45980354-c1a2ef00-c01f-11e8-964b-27c7a21d34ec.jpg)

Documentation/example in Readme is also provided.